### PR TITLE
Added custom appID insertion to be added on requests to help developers

### DIFF
--- a/src/capsolver/__init__.py
+++ b/src/capsolver/__init__.py
@@ -5,6 +5,7 @@ from capsolver.error import  InvalidRequestError, IncompleteJobError, RateLimitE
 
 api_base = os.environ.get("CAPSOLVER_API_BASE", "https://api.capsolver.com")
 api_key = os.environ.get("CAPSOLVER_API_KEY")
+appID = os.environ.get("CAPSOLVER_APP_ID")
 solve = Capsolver.solve
 balance = Capsolver.balance
 proxy = None
@@ -25,5 +26,6 @@ __all__ = [
 
     "api_base",
     "api_key",
+    "appId",
     "proxy",
 ]

--- a/src/capsolver/__init__.py
+++ b/src/capsolver/__init__.py
@@ -5,7 +5,7 @@ from capsolver.error import  InvalidRequestError, IncompleteJobError, RateLimitE
 
 api_base = os.environ.get("CAPSOLVER_API_BASE", "https://api.capsolver.com")
 api_key = os.environ.get("CAPSOLVER_API_KEY")
-appID = os.environ.get("CAPSOLVER_APP_ID")
+appId = os.environ.get("CAPSOLVER_APP_ID")
 solve = Capsolver.solve
 balance = Capsolver.balance
 proxy = None

--- a/src/capsolver/api_requestor.py
+++ b/src/capsolver/api_requestor.py
@@ -49,9 +49,10 @@ def _make_session():
 
 
 class APIRequestor:
-    def __init__(self, key=None, api_base=None):
+    def __init__(self, key=None, api_base=None, appId=None):
         self.api_base = api_base or capsolver.api_base
         self.api_key = key or capsolver.api_key
+        self.appId = appId or capsolver.appId
 
     def request(self, method, url, params=None, headers=None, request_timeout=None):
         result = self.request_raw(method.lower(), url, params=params, supplied_headers=headers, request_timeout=request_timeout)
@@ -113,8 +114,10 @@ class APIRequestor:
         abs_url = "%s%s" % (self.api_base, url)
         headers = self._validate_headers(supplied_headers)
         json_data = {
-            "clientKey":self.api_key,
+            "clientKey":self.api_key
         }
+        if capsolver.appid and capsolver.appid.strip():
+            json_data["appId"] = self.appId
         json_data.update(params)
         headers = self.request_headers(headers)
         if not hasattr(_thread_context, "session"):

--- a/src/capsolver/api_requestor.py
+++ b/src/capsolver/api_requestor.py
@@ -116,7 +116,7 @@ class APIRequestor:
         json_data = {
             "clientKey":self.api_key
         }
-        if capsolver.appid and capsolver.appid.strip():
+        if self.appId:
             json_data["appId"] = self.appId
         json_data.update(params)
         headers = self.request_headers(headers)


### PR DESCRIPTION
Now developers can enter `capsolver.appId = "my id"` and have their app id added in all requests automatically.