### PR TITLE
improve developer experience when using https debug

### DIFF
--- a/src/capsolver/__init__.py
+++ b/src/capsolver/__init__.py
@@ -8,6 +8,7 @@ api_key = os.environ.get("CAPSOLVER_API_KEY")
 solve = Capsolver.solve
 balance = Capsolver.balance
 proxy = None
+verify_ssl = True
 
 
 __all__ = [
@@ -26,4 +27,5 @@ __all__ = [
     "api_base",
     "api_key",
     "proxy",
+    "verify_ssl",
 ]

--- a/src/capsolver/api_requestor.py
+++ b/src/capsolver/api_requestor.py
@@ -52,6 +52,7 @@ class APIRequestor:
     def __init__(self, key=None, api_base=None):
         self.api_base = api_base or capsolver.api_base
         self.api_key = key or capsolver.api_key
+        self.verify_ssl = capsolver.verify_ssl
 
     def request(self, method, url, params=None, headers=None, request_timeout=None):
         result = self.request_raw(method.lower(), url, params=params, supplied_headers=headers, request_timeout=request_timeout)
@@ -120,7 +121,7 @@ class APIRequestor:
         if not hasattr(_thread_context, "session"):
             _thread_context.session = _make_session()
         try:
-            result = _thread_context.session.request(method, abs_url, headers=headers, json=json_data, timeout=request_timeout if request_timeout else TIMEOUT_SECS)
+            result = _thread_context.session.request(method, abs_url, headers=headers, json=json_data, timeout=request_timeout if request_timeout else TIMEOUT_SECS, verify=self.verify_ssl)
         except requests.exceptions.Timeout as e:
             raise error.Timeout("Request timed out") from e
         except requests.exceptions.RequestException as e:

--- a/test/verify_ssl.py
+++ b/test/verify_ssl.py
@@ -1,0 +1,14 @@
+import capsolver
+
+print("api host",capsolver.api_base)
+print("api key",capsolver.api_key)
+
+capsolver.verify_ssl = False
+
+solution = capsolver.solve({
+    "type":             "ReCaptchaV2TaskProxyLess",
+    "websiteKey":       "6Le-wvkSAAAAAPBMRTvw0Q4Muexq9bi0DJwx_mJ-",
+    "websiteURL":       "https://www.google.com/recaptcha/api2/demo",
+})
+
+print(solution)


### PR DESCRIPTION
### background
I got pain when i using https debug with capsolver_python. I always got `urllib3.exceptions.SSLError`


### Feature
now developer can use `capsolver.verify_ssl = False` for disable urllib3 verify_ssl